### PR TITLE
Add interactive particle vortex simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Particle Vortex</title>
+<style>
+    :root {
+        color-scheme: dark;
+    }
+    * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+    }
+    body {
+        background: radial-gradient(circle at center, rgba(40, 50, 90, 0.25) 0%, rgba(5, 7, 15, 1) 65%);
+        font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        color: #f3f5ff;
+        overflow: hidden;
+        height: 100vh;
+        width: 100vw;
+        display: flex;
+        align-items: stretch;
+        justify-content: stretch;
+        position: relative;
+    }
+    header {
+        position: absolute;
+        top: 24px;
+        left: 32px;
+        letter-spacing: 0.35rem;
+        font-size: clamp(1.1rem, 2vw + 0.6rem, 2.4rem);
+        font-weight: 600;
+        text-transform: uppercase;
+        pointer-events: none;
+        color: #f6f9ff;
+        text-shadow: 0 0 12px rgba(116, 193, 255, 0.35);
+        mix-blend-mode: screen;
+    }
+    footer {
+        position: absolute;
+        bottom: 24px;
+        left: 32px;
+        font-size: clamp(0.7rem, 1vw + 0.4rem, 1rem);
+        letter-spacing: 0.08rem;
+        pointer-events: none;
+        color: rgba(205, 217, 255, 0.75);
+        text-shadow: 0 0 6px rgba(98, 181, 255, 0.45);
+        mix-blend-mode: screen;
+    }
+    canvas {
+        flex: 1;
+        width: 100%;
+        height: 100%;
+        display: block;
+        filter: contrast(115%) saturate(130%);
+    }
+</style>
+</head>
+<body>
+    <header>Particle Vortex</header>
+    <canvas id="space"></canvas>
+    <footer>Click and hold to create black hole &mdash; Release to free particles</footer>
+<script>
+(() => {
+    const canvas = document.getElementById('space');
+    const ctx = canvas.getContext('2d');
+
+    const DPR = Math.min(window.devicePixelRatio || 1, 2);
+    let width = 0;
+    let height = 0;
+
+    const particleCount = 480;
+    const particles = [];
+    const palette = [
+        '#ffffff',
+        '#8fe1ff',
+        '#63c1ff',
+        '#c790ff',
+        '#ff8fe7',
+        '#ffd3f9'
+    ];
+
+    const pointer = { x: 0, y: 0 };
+    let blackHoleActive = false;
+    let blackHoleRadius = 0;
+    let blackHolePulse = 0;
+
+    const rand = (min, max) => Math.random() * (max - min) + min;
+
+    class Particle {
+        constructor() {
+            this.reset(true);
+        }
+        reset(initial = false) {
+            this.x = rand(0, width);
+            this.y = rand(0, height);
+            const angle = rand(0, Math.PI * 2);
+            const speed = rand(0.1, 0.6);
+            this.vx = Math.cos(angle) * speed;
+            this.vy = Math.sin(angle) * speed;
+            this.size = rand(1.2, 2.6);
+            this.color = palette[Math.floor(rand(0, palette.length))];
+            this.twinkleSpeed = rand(0.005, 0.02);
+            this.twinkleOffset = rand(0, Math.PI * 2);
+            this.floatTimer = initial ? rand(0, Math.PI * 2) : 0;
+            this.prevX = this.x;
+            this.prevY = this.y;
+        }
+        update(delta) {
+            this.prevX = this.x;
+            this.prevY = this.y;
+
+            if (!blackHoleActive) {
+                this.floatTimer += delta * 0.0005;
+                const driftStrength = 0.18;
+                this.vx += Math.cos(this.floatTimer * 1.7) * driftStrength * delta * 0.0001;
+                this.vy += Math.sin(this.floatTimer * 1.3) * driftStrength * delta * 0.0001;
+            }
+
+            this.x += this.vx * delta * 0.06;
+            this.y += this.vy * delta * 0.06;
+
+            const margin = 40;
+            if (this.x < -margin || this.x > width + margin || this.y < -margin || this.y > height + margin) {
+                this.reset();
+            }
+        }
+    }
+
+    function initParticles() {
+        particles.length = 0;
+        for (let i = 0; i < particleCount; i += 1) {
+            particles.push(new Particle());
+        }
+    }
+
+    function resize() {
+        const rect = canvas.getBoundingClientRect();
+        width = rect.width * DPR;
+        height = rect.height * DPR;
+        canvas.width = width;
+        canvas.height = height;
+        ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+    }
+
+    function drawParticle(particle) {
+        const dx = particle.x - particle.prevX;
+        const dy = particle.y - particle.prevY;
+        const speed = Math.hypot(dx, dy);
+
+        ctx.lineWidth = particle.size * 0.6;
+        ctx.strokeStyle = particle.color;
+        ctx.shadowBlur = Math.max(8, speed * 12);
+        ctx.shadowColor = particle.color;
+        ctx.beginPath();
+        ctx.moveTo(particle.prevX, particle.prevY);
+        ctx.lineTo(particle.x, particle.y);
+        ctx.stroke();
+
+        const pulse = 0.6 + Math.sin(performance.now() * particle.twinkleSpeed + particle.twinkleOffset) * 0.4;
+        const radius = particle.size * pulse;
+        ctx.fillStyle = particle.color;
+        ctx.shadowBlur = 18;
+        ctx.beginPath();
+        ctx.arc(particle.x, particle.y, radius, 0, Math.PI * 2);
+        ctx.fill();
+    }
+
+    function drawBlackHole() {
+        if (!blackHoleActive) return;
+        blackHolePulse = (blackHolePulse + 0.12) % (Math.PI * 2);
+        const baseRadius = Math.max(blackHoleRadius, 20);
+        const haloRadius = baseRadius + Math.sin(blackHolePulse) * 6 + 8;
+        const gradient = ctx.createRadialGradient(pointer.x, pointer.y, baseRadius * 0.2, pointer.x, pointer.y, haloRadius);
+        gradient.addColorStop(0, 'rgba(15, 10, 25, 1)');
+        gradient.addColorStop(0.35, 'rgba(25, 20, 40, 0.95)');
+        gradient.addColorStop(0.58, 'rgba(76, 115, 255, 0.35)');
+        gradient.addColorStop(0.9, 'rgba(10, 15, 35, 0)');
+        ctx.fillStyle = gradient;
+        ctx.beginPath();
+        ctx.arc(pointer.x, pointer.y, haloRadius, 0, Math.PI * 2);
+        ctx.fill();
+
+        ctx.save();
+        ctx.strokeStyle = 'rgba(160, 210, 255, 0.4)';
+        ctx.lineWidth = 1.4;
+        ctx.shadowBlur = 15;
+        ctx.shadowColor = 'rgba(106, 157, 255, 0.8)';
+        ctx.beginPath();
+        ctx.arc(pointer.x, pointer.y, baseRadius * 0.5, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.restore();
+    }
+
+    let lastTime = performance.now();
+
+    function animate(now) {
+        const delta = Math.min(now - lastTime, 40);
+        lastTime = now;
+
+        ctx.fillStyle = 'rgba(5, 8, 18, 0.2)';
+        ctx.fillRect(0, 0, width, height);
+
+        if (blackHoleActive) {
+            const strength = 2200;
+            particles.forEach(particle => {
+                const dx = pointer.x - particle.x;
+                const dy = pointer.y - particle.y;
+                const distSq = dx * dx + dy * dy + 0.0001;
+                const dist = Math.sqrt(distSq);
+                const pull = (strength / distSq) * delta * 0.06;
+                particle.vx += dx / dist * pull;
+                particle.vy += dy / dist * pull;
+
+                const maxSpeed = 12;
+                const speed = Math.hypot(particle.vx, particle.vy);
+                if (speed > maxSpeed) {
+                    const scale = maxSpeed / speed;
+                    particle.vx *= scale;
+                    particle.vy *= scale;
+                }
+            });
+            blackHoleRadius = Math.min(60, blackHoleRadius + delta * 0.12);
+        } else {
+            blackHoleRadius = Math.max(0, blackHoleRadius - delta * 0.2);
+        }
+
+        particles.forEach(particle => {
+            particle.update(delta);
+            drawParticle(particle);
+        });
+
+        drawBlackHole();
+        requestAnimationFrame(animate);
+    }
+
+    function scatterParticles() {
+        const scatterStrength = 6;
+        particles.forEach(particle => {
+            const dx = particle.x - pointer.x;
+            const dy = particle.y - pointer.y;
+            const dist = Math.max(Math.hypot(dx, dy), 4);
+            const dirX = dx / dist;
+            const dirY = dy / dist;
+            const randomSpread = rand(-Math.PI / 6, Math.PI / 6);
+            const cos = Math.cos(randomSpread);
+            const sin = Math.sin(randomSpread);
+            const outX = dirX * cos - dirY * sin;
+            const outY = dirX * sin + dirY * cos;
+            const speed = scatterStrength * rand(0.8, 1.6);
+            particle.vx = outX * speed;
+            particle.vy = outY * speed;
+        });
+    }
+
+    canvas.addEventListener('pointerdown', event => {
+        blackHoleActive = true;
+        pointer.x = (event.clientX - canvas.getBoundingClientRect().left) * DPR;
+        pointer.y = (event.clientY - canvas.getBoundingClientRect().top) * DPR;
+    });
+
+    window.addEventListener('pointerup', () => {
+        if (blackHoleActive) {
+            blackHoleActive = false;
+            scatterParticles();
+        }
+    });
+
+    window.addEventListener('pointermove', event => {
+        const rect = canvas.getBoundingClientRect();
+        pointer.x = (event.clientX - rect.left) * DPR;
+        pointer.y = (event.clientY - rect.top) * DPR;
+    });
+
+    window.addEventListener('resize', () => {
+        resize();
+    });
+
+    resize();
+    initParticles();
+    requestAnimationFrame(animate);
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone HTML page that renders a glowing particle field with canvas
- implement mouse-driven black hole attraction and release scattering effects with animated trails
- overlay instructions and title styling to match the requested presentation

## Testing
- python -m http.server 8000 &
- curl -I http://127.0.0.1:8000/index.html


------
https://chatgpt.com/codex/tasks/task_e_68caa79f350c83318533cb6432a6a838